### PR TITLE
fix: states:SendTaskSuccess and states:SendTaskFailure only supports "Resource": "*"

### DIFF
--- a/stacks/StepFunction.ts
+++ b/stacks/StepFunction.ts
@@ -75,8 +75,6 @@ export function StepFunction({ stack }: StackContext) {
   stateMachine.grantRead(apiLambda);
   apiLambda.addEnvironment("STATE_MACHINE_ARN", stateMachine.stateMachineArn);
 
-  // This is far away from best practice (see *) but CloudFormation just sucks with Cyclical Dependencies so I don't want to spend any more time on this
-  // Don't do the star on prod. I'm sorry IAM God.
   approvalReceiverLambda.addToRolePolicy(
     new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,


### PR DESCRIPTION
hey @AlessandroVol23, you are not wrong here =)

If you check the AWS Console, when creating a policy for the Callback Pattern `states:SendTaskSuccess` and `states:SendTaskFailure,` you can't specify the resource ARN, it selects "All" (`*`).

![CleanShot 2024-03-22 at 22 58 46](https://github.com/awsfundamentals-hq/sfn-wait-for-callback/assets/829902/e97ea9c0-32d3-4430-971f-85166a68c662)

You can confirm that in the AWS Step Functions IAM actions documentation:

https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsstepfunctions.html

The `SendTaskFailure` and `SendTaskSuccess` don't have any required Resource Types value (meaning is not necessary to specify the ARN of any resource)

![CleanShot 2024-03-22 at 23 08 44](https://github.com/awsfundamentals-hq/sfn-wait-for-callback/assets/829902/897e8dc8-9339-4cb1-bb92-2f7b42501713)

And the documentation says above:

> The Resource types column indicates whether the action supports resource-level permissions. If the column is empty, then the action does not support resource-level permissions, and you must specify all resources ("*") in your policy.

You don't need to be sorry!

You are correct 😄